### PR TITLE
Parameterize npmbox and npmunbox paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Given some package, like `express` this command will create a archive file of th
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows no output whatsoever.
+		-v, -path			 Specify a path to write the .npmbox file(s).
 
 You must specify at least one package.
 
@@ -56,6 +57,7 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows additional output which is normally hidden.
+		-p, path			 Specify a path from which to read the .npmbox file(s).
 		-g, -global          Installs package globally as if --global was passed to npm.
 		-C, -prefix          npm --prefix switch.
 		-S, -save            npm --save switch.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Given some package, like `express` this command will create a archive file of th
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows no output whatsoever.
-		-p, -path			 Specify the path to a folder where the .npmbox file(s) will be written.
+		-p, -path            Specify the path to a folder where the .npmbox file(s) will be written.
 
 You must specify at least one package.
 
@@ -57,7 +57,7 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows additional output which is normally hidden.
-		-p, path			 Specify the path to a folder from which the .npmbox file(s) will be read.
+		-p, path             Specify the path to a folder from which the .npmbox file(s) will be read.
 		-g, -global          Installs package globally as if --global was passed to npm.
 		-C, -prefix          npm --prefix switch.
 		-S, -save            npm --save switch.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Given some package, like `express` this command will create a archive file of th
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows no output whatsoever.
-		-v, -path			 Specify a path to write the .npmbox file(s).
+		-p, -path			 Specify the path to a folder where the .npmbox file(s) will be written.
 
 You must specify at least one package.
 
@@ -57,7 +57,7 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
 
 		-v, -verbose         Shows npm output which is normally hidden.
 		-s, -silent          Shows additional output which is normally hidden.
-		-p, path			 Specify a path from which to read the .npmbox file(s).
+		-p, path			 Specify the path to a folder from which the .npmbox file(s) will be read.
 		-g, -global          Installs package globally as if --global was passed to npm.
 		-C, -prefix          npm --prefix switch.
 		-S, -save            npm --save switch.

--- a/npmbox.js
+++ b/npmbox.js
@@ -10,6 +10,10 @@ var utils = require("./utils.js");
 
 var argv = require("optimist")
 	.boolean(["v","verbose","s","silent"])
+	.options("p", {
+		alias: "path",
+		default: process.cwd()
+	})
 	.argv;
 
 var args = argv._;
@@ -25,6 +29,7 @@ if (args.length<1 || argv.help) {
 	console.log("");
 	console.log("  -v, -verbose         Shows additional output which is normally hidden.");
 	console.log("  -s, -silent          Shows additional output which is normally hidden.");
+	console.log("  -p, -path            Specify a path to write the .npmbox file(s).");
 	console.log("");
 	process.exit(0);
 }
@@ -32,6 +37,7 @@ if (args.length<1 || argv.help) {
 var options = {
 	verbose: argv.v || argv.verbose || false,
 	silent: argv.s || argv.silent || false,
+	path: argv.p || argv.path || false
 };
 
 var sources = args;

--- a/npmbox.js
+++ b/npmbox.js
@@ -29,7 +29,7 @@ if (args.length<1 || argv.help) {
 	console.log("");
 	console.log("  -v, -verbose         Shows additional output which is normally hidden.");
 	console.log("  -s, -silent          Shows additional output which is normally hidden.");
-	console.log("  -p, -path            Specify a path to write the .npmbox file(s).");
+	console.log("  -p, -path            Specify the path to a folder where the .npmbox file(s) will be written.");
 	console.log("");
 	process.exit(0);
 }

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -13,7 +13,6 @@
 	var rimraf = require("rimraf");
 	var is = require("is");
 	var Decompress = require("decompress");
-
 	var cwd = process.cwd();
 	var work = path.resolve(cwd,".npmbox.work");
 	var cache = path.resolve(cwd,".npmbox.cache");
@@ -156,7 +155,7 @@
 
 			//npm.commands.cache.add(name,ver,where,scrub,cb)
 			npm.commands.cache.add(packageName,null,null,false,function(err){
-				if (err) return callback("Error occurred downloading '"+packageName+"' to cache.");
+				if (err) return callback("Error occured downloading '"+packageName+"' to cache.");
 				done(packageName);
 			});
 
@@ -168,7 +167,7 @@
 	};
 
 	var box = function(source,options,callback) {
-		var target = path.resolve(cwd,source+".npmbox");
+		var target = path.resolve(options.path,source+".npmbox");
 		if (fs.existsSync(target)) {
 			callback("An .npmbox file already exist with this name.  Please remove it and try again.");
 			return;
@@ -232,9 +231,8 @@
 
 	var unbox = function(source,options,callback) {
 		var target = source.replace(/\.npmbox$/,"");
-
 		if (!fs.existsSync(source)) {
-			source = path.resolve(cwd,source+".npmbox");
+			source = path.resolve(options.path,source+".npmbox");
 			if (!fs.existsSync(source)) {
 				callback("No .npmbox file found: "+source);
 				return;

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -13,6 +13,7 @@
 	var rimraf = require("rimraf");
 	var is = require("is");
 	var Decompress = require("decompress");
+	
 	var cwd = process.cwd();
 	var work = path.resolve(cwd,".npmbox.work");
 	var cache = path.resolve(cwd,".npmbox.cache");
@@ -155,7 +156,7 @@
 
 			//npm.commands.cache.add(name,ver,where,scrub,cb)
 			npm.commands.cache.add(packageName,null,null,false,function(err){
-				if (err) return callback("Error occured downloading '"+packageName+"' to cache.");
+				if (err) return callback("Error occurred downloading '"+packageName+"' to cache.");
 				done(packageName);
 			});
 

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -45,10 +45,10 @@ if (args.length<1 || argv.help) {
 	console.log("  -g, -global          Installs package globally as if --global was passed to npm.");
 	console.log("  -C, -prefix          npm --prefix switch.");
 	console.log("  -S, -save            npm --save switch.");
-	console.log("  -D, -save-dev        npm --save-dev swtich.");
-	console.log("  -O, -save-optional   npm --save-optional swtich.");
-	console.log("  -B, -save-bundle     npm --save-bundle swtich.");
-	console.log("  -E, -save-exact      npm --save-exact swtich.");
+	console.log("  -D, -save-dev        npm --save-dev switch.");
+	console.log("  -O, -save-optional   npm --save-optional switch.");
+	console.log("  -B, -save-bundle     npm --save-bundle switch.");
+	console.log("  -E, -save-exact      npm --save-exact switch.");
 	console.log("");
 	process.exit(0);
 }

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -41,7 +41,7 @@ if (args.length<1 || argv.help) {
 	console.log("");
 	console.log("  -v, -verbose         Shows npm output which is normally hidden.");
 	console.log("  -s, -silent          Shows additional output which is normally hidden.");
-	console.log("  -p, -path            Specify a path from which to read the .npmbox file(s).");
+	console.log("  -p, -path            Specify the path to a folder from which the .npmbox file(s) will be read.");
 	console.log("  -g, -global          Installs package globally as if --global was passed to npm.");
 	console.log("  -C, -prefix          npm --prefix switch.");
 	console.log("  -S, -save            npm --save switch.");

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -21,7 +21,12 @@ var argv = require("optimist")
 		"O","save-optional",
 		"B","save-bundle",
 		"E","save-exact"
-	]).argv;
+	])
+	.options("p", {
+		alias: "path",
+		default: process.cwd()
+	})
+	.argv;
 
 var args = argv._;
 if (args.length<1 || argv.help) {
@@ -36,13 +41,14 @@ if (args.length<1 || argv.help) {
 	console.log("");
 	console.log("  -v, -verbose         Shows npm output which is normally hidden.");
 	console.log("  -s, -silent          Shows additional output which is normally hidden.");
+	console.log("  -p, -path            Specify a path from which to read the .npmbox file(s).");
 	console.log("  -g, -global          Installs package globally as if --global was passed to npm.");
 	console.log("  -C, -prefix          npm --prefix switch.");
 	console.log("  -S, -save            npm --save switch.");
-	console.log("  -D, -save-dev        npm --save-dev switch.");
-	console.log("  -O, -save-optional   npm --save-optional switch.");
-	console.log("  -B, -save-bundle     npm --save-bundle switch.");
-	console.log("  -E, -save-exact      npm --save-exact switch.");
+	console.log("  -D, -save-dev        npm --save-dev swtich.");
+	console.log("  -O, -save-optional   npm --save-optional swtich.");
+	console.log("  -B, -save-bundle     npm --save-bundle swtich.");
+	console.log("  -E, -save-exact      npm --save-exact swtich.");
 	console.log("");
 	process.exit(0);
 }
@@ -55,7 +61,8 @@ var options = {
 	"save-dev": argv.D || argv["save-dev"] || false,
 	"save-optional": argv.O || argv["save-optional"] || false,
 	"save-bundle": argv.B || argv["save-bundle"] || false,
-	"save-exact": argv.E || argv["save-exact"] || false
+	"save-exact": argv.E || argv["save-exact"] || false,
+	path: argv.p || argv.path || false
 };
 if (argv.C || argv.prefix) options.prefix = argv.C || argv.prefix;
 


### PR DESCRIPTION
It ended up being useful for me to be able to define where the .npmbox files were written to, and where they would be read from on the other end. I added a path parameter to npmbox and npmunbox to define these paths.