### PR TITLE
`tar.gz` workaround / Legacy behavior

### DIFF
--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -346,7 +346,6 @@
 
 		var getTargets = function() {
 			targets = {};
-			targets[path.basename(source).replace(/\.npmbox$/,"")] = true;
 
 			// Unfortunately, the `tar.gz` package at v1.0.2 will
 			// sometimes make its callback before it's done
@@ -376,6 +375,12 @@
 					});
 
 					targets = Object.keys(targets);
+					if (targets.length === 0) {
+						// This is a legacy `.npmbox` file which instead of having embedded flag
+						// files just uses the name of the archive file to determine what to
+						// install.
+						targets = [path.basename(source).replace(/\.npmbox$/,"")];
+					}
 					next();
 				});
 			};

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -353,7 +353,7 @@
 			// package have other bugs that prevent extraction from
 			// working at all. What we do here is keep `readdir`ing
 			// until the contents of the directory settle.
-			var dirCount = 0;
+			var dirCount = -1;
 			var doScan = function() {
 				fs.readdir(cache,function(err,files){
 					if (err) return done(err);

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -348,17 +348,39 @@
 			targets = {};
 			targets[path.basename(source).replace(/\.npmbox$/,"")] = true;
 
-			fs.readdir(cache,function(err,files){
-				if (err) return done(err);
-				files.filter(function(file){
-					return file.match(/\.npmbox$/);
-				}).forEach(function(file){
-					file = path.basename(file).replace(/\.npmbox$/,"");
-					targets[file] = true;
+			// Unfortunately, the `tar.gz` package at v1.0.2 will
+			// sometimes make its callback before it's done
+			// extracting all the files, but _later_ versions of the
+			// package have other bugs that prevent extraction from
+			// working at all. What we do here is keep `readdir`ing
+			// until the contents of the directory settle.
+			var dirCount = 0;
+			var doScan = function() {
+				fs.readdir(cache,function(err,files){
+					if (err) return done(err);
+
+					if (files.length !== dirCount) {
+						// Wait a moment to see if more
+						// files get extracted. See
+						// comment above.
+						dirCount = files.length;
+						setTimeout(doScan, 250);
+						return;
+					}
+
+					files.filter(function(file){
+						return file.match(/\.npmbox$/);
+					}).forEach(function(file){
+						file = path.basename(file).replace(/\.npmbox$/,"");
+						targets[file] = true;
+					});
+
+					targets = Object.keys(targets);
+					next();
 				});
-				targets = Object.keys(targets);
-				next();
-			});
+			};
+
+			doScan();
 		};
 
 		var unpack = function() {


### PR DESCRIPTION
This PR combines two bits of work I did while looking at issue #31, which are independent of that work:

* Works around the early untar callback problem with the `tar.gz` package.
* Stops doing the legacy unbox behavior of looking at the box file name, when the box is in the newer form.

I hope you find this useful. Happy Thanksgiving!