### PR TITLE
Better flag files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npm, inc. is actively working on this problem as we speak.  Read this blog post 
 
 5). I used to be able to create multiple .npmbox files with a single command. Why did that change.
 
-In order to support multiple npm packages in a single .npmbox file we had to change how this works.  It's still possible to create multiple .npmbox per package, but you will just need to runt he command multiple times.
+In order to support multiple npm packages in a single .npmbox file we had to change how this works.  It's still possible to create multiple .npmbox per package, but you will just need to run the command multiple times.
 
 6). But I wanted it to work the old way with one .npmbox file per package.
 

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -253,7 +253,9 @@
 						if (!target) setTarget(packageInfo.name);
 						rack();
 					}
-					return done("Package has no name");
+					else {
+						return done("Package has no name");
+					}
 				});
 			}
 			else {

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -18,18 +18,16 @@
 	var work = path.resolve(cwd,".npmbox.work");
 	var cache = path.resolve(cwd,".npmbox.cache");
 
-	// This takes an install target (typically a simple package name, but
-	// sometimes a path or a general URL) and converts it into a form that is
-	// suitable as a simple filesystem component (name without slashes),
-	// including a `.npmbox` suffix.
+	// This takes an install target (typically a simple package name, but sometimes a path or a general URL) and
+	// converts it into a form that is suitable as a simple filesystem component (name without slashes), including a
+	// `.npmbox` suffix.
 	var encodeTarget = function(target) {
 		return encodeURIComponent(target)+".npmbox";
 	}
 
-	// This reverses the action of `encodeTarget()`, and also strips away the
-	// directory prefix.
+	// This reverses the action of `encodeTarget()`, and also strips away the directory prefix.
 	var decodeTarget = function(encoded) {
-		encoded = path.basename(encoded).replace(/\.npmbox$/, "");
+		encoded = path.basename(encoded).replace(/\.npmbox$/,"");
 		return decodeURIComponent(encoded);
 	}
 
@@ -144,7 +142,7 @@
 			var packageType = packageDetails && packageDetails.type || null;
 
 			if(packageType==="git" || packageType==="hosted") {
-				npm.commands.cache.add(packageName,null,null,false,function(err, packageInfo) {
+				npm.commands.cache.add(packageName,null,null,false,function(err,packageInfo) {
 					if (err) return callback(err);
 					lookupPackageDependencies(packageInfo);
 
@@ -262,7 +260,7 @@
 
 			if (packageType==="git" || packageType==="hosted") {
 				console.log("  Cloning "+source);
-				npm.commands.cache.add(source,null,null,false,function(err, packageInfo) {
+				npm.commands.cache.add(source,null,null,false,function(err,packageInfo) {
 					if (err) return done(err);
 					if (packageInfo && packageInfo.name) {
 						if (!target) setTarget(packageInfo.name);
@@ -362,23 +360,18 @@
 		var getTargets = function() {
 			targets = {};
 
-			// Unfortunately, the `tar.gz` package at v1.0.2 will
-			// sometimes make its callback before it's done
-			// extracting all the files, but _later_ versions of the
-			// package have other bugs that prevent extraction from
-			// working at all. What we do here is keep `readdir`ing
-			// until the contents of the directory settle.
+			// Unfortunately, the `tar.gz` package at v1.0.2 will sometimes make its callback before it's done
+			// extracting all the files, but _later_ versions of the package have other bugs that prevent extraction
+			// from working at all. What we do here is keep `readdir`ing until the contents of the directory settle.
 			var dirCount = -1;
 			var doScan = function() {
 				fs.readdir(cache,function(err,files){
 					if (err) return done(err);
 
 					if (files.length !== dirCount) {
-						// Wait a moment to see if more
-						// files get extracted. See
-						// comment above.
+						// Wait a moment to see if more files get extracted. See comment above.
 						dirCount = files.length;
-						setTimeout(doScan, 250);
+						setTimeout(doScan,250);
 						return;
 					}
 
@@ -390,9 +383,8 @@
 
 					targets = Object.keys(targets);
 					if (targets.length === 0) {
-						// This is a legacy `.npmbox` file which instead of having embedded flag
-						// files just uses the name of the archive file to determine what to
-						// install.
+						// This is a legacy `.npmbox` file which instead of having embedded flag files just uses the name of the archive file to determine what
+						// to install.
 						targets = [decodeTarget(source)];
 					}
 					next();


### PR DESCRIPTION
This PR fixes the naming of flag files inside box archives, such that names for things other than unscoped packages will work. Notably, this fixes the case of doing a top-level install of a package named by a URL or Github `account/repo` pair.

In addition to the main thrust of the PR:
* I fixed a bug whereby `npmbox` would incorrectly complain about unnamed packages.
* I cleaned up spacing and line width (mostly introduced by my previous PR) to better match the existing coding conventions.
* I fixed a minor typo in the README file.

**Note:** I kept the spacing tweaks in a separate commit. If you'd prefer not to include that, let me know and I'll rework the PR.

**BTW/FTR:** This PR fixes tangentially-related problems I found while working on issue #31.