### PR TITLE
Tar and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ npm, inc. is actively working on this problem as we speak.  Read this blog post 
 
 5). I used to be able to create multiple .npmbox files with a single command. Why did that change.
 
-In order to support multiple npm packages in a single .npmbox file we had to change how this works.  It's still possible to create multiple .npmbox per package, but you will just need to runt he command multiple times.
+In order to support multiple npm packages in a single .npmbox file we had to change how this works.  It's still possible to create multiple .npmbox per package, but you will just need to run the command multiple times.
 
 6). But I wanted it to work the old way with one .npmbox file per package.
 

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -290,7 +290,9 @@
 						if (!target) setTarget(packageInfo.name);
 						rack();
 					}
-					return done("Package has no name");
+					else {
+						return done("Package has no name");
+					}
 				});
 			}
 			else {

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -11,7 +11,6 @@
 	var fsx = require("fs-extra");
 	var path = require("path");
 	var targz = require("tar.gz");
-	var rimraf = require("rimraf");
 	var is = require("is");
 	var npa = require("npm-package-arg");
 
@@ -29,14 +28,14 @@
 			else callback();
 		};
 
-		if (fs.existsSync(cache)) rimraf(cache,wait);
+		if (fs.existsSync(cache)) fsx.remove(cache,wait);
 		else callback();
 	};
 
 	var cleanWork = function(callback) {
 		process.chdir(cwd);
 
-		if (fs.existsSync(work)) rimraf(work,callback);
+		if (fs.existsSync(work)) fsx.remove(work,callback);
 		else callback();
 	};
 

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -18,6 +18,21 @@
 	var work = path.resolve(cwd,".npmbox.work");
 	var cache = path.resolve(cwd,".npmbox.cache");
 
+	// This takes an install target (typically a simple package name, but
+	// sometimes a path or a general URL) and converts it into a form that is
+	// suitable as a simple filesystem component (name without slashes),
+	// including a `.npmbox` suffix.
+	var encodeTarget = function(target) {
+		return encodeURIComponent(target)+".npmbox";
+	}
+
+	// This reverses the action of `encodeTarget()`, and also strips away the
+	// directory prefix.
+	var decodeTarget = function(encoded) {
+		encoded = path.basename(encoded).replace(/\.npmbox$/, "");
+		return decodeURIComponent(encoded);
+	}
+
 	var cleanCache = function(callback) {
 		process.chdir(cwd);
 
@@ -257,7 +272,7 @@
 		};
 
 		var rack = function() {
-			var flagfile = path.resolve(cache,source+".npmbox");
+			var flagfile = path.resolve(cache,encodeTarget(source));
 			fs.writeFileSync(flagfile,source);
 
 			npmDependencies(source,options,function(err,deps){
@@ -370,12 +385,10 @@
 		var install = function() {
 			if (!options.silent) console.log("  Installing "+target+"...");
 
-			var packageName = path.basename(target);
-
-			npmInstall(packageName,function(err){
+			npmInstall(target,function(err){
 				if (err) {
-					if (!options.silent) console.log("An error occurred while installing "+packageName+".");
-					if (!options.silent) console.log(packageName+" was not installed.");
+					if (!options.silent) console.log("An error occurred while installing "+target+".");
+					if (!options.silent) console.log(target+" was not installed.");
 					if (options.verbose) console.log(err);
 					return done();
 				}
@@ -393,7 +406,7 @@
 					return file.match(/\.npmbox$/);
 				}).forEach(function(file){
 					file = path.basename(file).replace(/\.npmbox$/,"");
-					targets[file] = true;
+					targets[decodeTarget(file)] = true;
 				});
 
 				targets = Object.keys(targets);

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -409,7 +409,7 @@
 			options.progress = false;
 			options.color = false;
 			options["ignore-scripts"] = true;
-			options["cache-min"] = 99999;
+			options["cache-min"] = 1000 * 365.25 * 24 * 60 * 60; // a thousand years
 			options["fetch-retries"] = 0;
 			options["fetch-retry-factor"] = 0;
 			options["fetch-retry-mintimeout"] = 1;

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "optimist": "0.6.1",
     "npm-package-arg": "4.2.0",
     "tar.gz": "1.0.2",
-    "rimraf": "2.5.2",
     "npm": "3.10.3"
   },
   "devDependencies": {},

--- a/package.json
+++ b/package.json
@@ -54,12 +54,13 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-	  "is": "3.1.0",
-	  "optimist": "0.6.1",
-	  "npm-package-arg": "4.2.0",
-	  "tar.gz": "1.0.2",
-	  "rimraf": "2.5.2",
-	  "npm": "3.10.3"
+    "fs-extra": "1.0.0",
+    "is": "3.1.0",
+    "optimist": "0.6.1",
+    "npm-package-arg": "4.2.0",
+    "tar.gz": "1.0.2",
+    "rimraf": "2.5.2",
+    "npm": "3.10.3"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
This PR fixes several issues that I ran across while trying to address issue #31 ("run npmbox on a local unpublished package").

* Fix issue #70 (`99999` for `cache-min`).
* Redo the `tar.gz` early-callback workaround to be more complete. I explicitly verified that this fixes issue #61 (unboxing a box of the module `forever`). Moreover, I suspect that this and the previous item collectively fix many other "why doesn't this unbox successfully?" type bugs.
* Fix a bug whereby `npmbox` would  incorrectly complain about unnamed packages.
* Fix how flag files get named inside archives, such that names for things other than unscoped packages will work. Notably, this fixes the case of doing a top-level install of a package named by a URL or Github `account/repo` pair.
* **Bonus:** I fixed a minor typo in the README file.

**Note:** To do the `tar.gz` fix, I ended up adding in the package `fs-extra`, which also includes `rimraf`'s exact functionality, so I removed the latter package.