### PR TITLE
Support local packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Sorry, I am only one person and I already have a full time job.  Using open sour
 
 3). When I run the command described above to install npmbox on my offline machine I get an error.
 
-This if frequently caused by incorrectly referencing where the ```.npmbox-cache``` file is.  Please check the section of the command ```---cache .\.npmbox-cache``` and make sure it is pointing at the correct location.
+This if frequently caused by incorrectly referencing where the `.npmbox-cache` file is.  Please check the section of the command `--cache .\.npmbox-cache` and make sure it is pointing at the correct location.
 
 4). When is npm going to add this functionality?
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,9 @@ or
 
     tar --no-same-owner --no-same-permissions -xvzf npmbox.npmbox
 
-NOTE: If for some reason ```--no-same-owner``` or ```--no-same-permissions``` do not work, remove them and adjust the permissions/ownership yourself.  You will need to ensure that npm can see all the files in the .npmbox.cache file structure.
+NOTE: If for some reason `--no-same-owner` or `--no-same-permissions` do not work, remove them and adjust the permissions/ownership yourself.  You will need to ensure that npm can see all the files in the .npmbox.cache file structure.
 
-NOTE: On some OSes it may also be necessary to drop the ```-z``` switch from the tar command as well.
+NOTE: On some OSes it may also be necessary to drop the `-z` switch from the tar command as well.
 
 NOTE: On windows you might not have the tar command.  You can use another zip utility (like 7-zip or winzip) to extract the file if you like.  Just please note that the file is a .tar.gz file and thus you may need to extract it twice, once for the zip, the second for the tar.  **If you do this, please make sure to remove the tar file from your local directory before running the npm command below.**
 
@@ -144,7 +144,7 @@ For windows...
 
     npm install --global --cache .\.npmbox.cache --optional --cache-min 99999999999 --shrinkwrap false npmbox
 
-NOTE: If you have a file called ```npmbox``` (no extension) in the local directory, this will not work correctly.  Please remove said ```npmbox``` file.
+NOTE: If you have a file called `npmbox` (no extension) in the local directory, this will not work correctly.  Please remove said `npmbox` file.
 
 6). Once npmbox is installed globally you can use it to install other .npmbox files:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You must specify at least one package.
 
 npmbox files end with the .npmbox extension.
 
-NOTE: When creating an archive file for a package destined to be installed on an offline machine clear your npm cache before using npmbox
+NOTE: When creating an archive file for a package destined to be installed on an offline machine clear your npm cache before using npmbox.
 
     npm cache clean
 
@@ -102,7 +102,7 @@ A particular use case with npmunbox comes up fairly often: **how do I use npmbox
 
 **On the system you want to install npmbox to, do the following:**
 
-1). Create a new directory
+1). Create a new directory:
 
     mkdir somedir
 
@@ -110,7 +110,7 @@ A particular use case with npmunbox comes up fairly often: **how do I use npmbox
 
     cd somedir
 
-3). Copy the npmbox.npmbox folder into this directory.
+3). Copy the npmbox.npmbox folder into this directory:
 
     cp /media/usb/npmbox.npmbox .
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ npmbox is intended to be a proof of concept with regards to this issue filled ag
 
 ## npmbox news
 
+UPDATE December 21, 2016: v4.1.0 of npmbox is out.
+  * Support for running npmbox on a top-level local package, e.g.
+    `npmbox path/to/my/package`. **Note:** You cannot be `cd`ed to the directory
+    to box. (That is, `npmbox .` won't work.) This may be addressed in a future
+    version.
+
 UPDATE December 20, 2016: v4.0.2 of npmbox is out.
   * Fix a couple issues which could cause npmbox to incorrectly try to use the
     network.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "npmbox",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "dependencies": {
     "assertion-error": {
       "version": "1.0.2",

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -180,8 +180,8 @@
 			var packageDetails = npa(packageName);
 			var packageType = packageDetails && packageDetails.type || null;
 
-			if(packageType==="git" || packageType==="hosted") {
-				npm.commands.cache.add(packageName,null,null,false,function(err, packageInfo) {
+			if(packageType==="git" || packageType==="hosted" || packageType==="local") {
+				npm.commands.cache.add(packageName,null,null,false,function(err,packageInfo) {
 					if (err) return callback(err);
 					lookupPackageDependencies(packageInfo);
 
@@ -297,9 +297,10 @@
 				return done(e);
 			}
 
-			if (packageType==="git" || packageType==="hosted") {
-				console.log("  Cloning "+source);
-				npm.commands.cache.add(source,null,null,false,function(err, packageInfo) {
+			if (packageType==="git" || packageType==="hosted" || packageType==="local") {
+				var doingWhat = (packageType==="local") ? "Copying" : "Cloning";
+				console.log("  "+doingWhat+" "+source);
+				npm.commands.cache.add(source,null,null,false,function(err,packageInfo) {
 					if (err) return done(err);
 					if (packageInfo && packageInfo.name) {
 						if (!target) setTarget(packageInfo.name);

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -271,9 +271,12 @@
 			});
 		};
 
-		var rack = function() {
-			var flagfile = path.resolve(cache,encodeTarget(source));
-			fs.writeFileSync(flagfile,source);
+		var rack = function(packageName) {
+			// **Note:** The given `packageName` is the same as the `source` for regular packages (that come from the
+			// registry), but in other cases (hosted, git, local) the name is instead constructed to refer to the
+			// package by its name and version as stored in the cache.
+			var flagfile = path.resolve(cache,encodeTarget(packageName));
+			fs.writeFileSync(flagfile,packageName);
 
 			npmDependencies(source,options,function(err,deps){
 				if (err) return done(err);
@@ -302,18 +305,21 @@
 				console.log("  "+doingWhat+" "+source);
 				npm.commands.cache.add(source,null,null,false,function(err,packageInfo) {
 					if (err) return done(err);
-					if (packageInfo && packageInfo.name) {
+					if (packageInfo && packageInfo.name && packageInfo.version) {
 						if (!target) setTarget(packageInfo.name);
-						rack();
+						// Because we just want to take the package from the cache when unboxing, instead of referring
+						// to the original `source` (which might be a local path or network reference), we instead
+						// rewrite it in a form that gets explicitly recognized while unboxing.
+						rack("file:"+packageInfo.name+"-"+packageInfo.version+".tgz");
 					}
 					else {
-						return done("Package has no name");
+						return done("Package has no name or no version");
 					}
 				});
 			}
 			else {
 				if (!target) setTarget(source);
-				rack();
+				rack(source);
 			}
 		};
 
@@ -385,6 +391,20 @@
 
 		var install = function() {
 			if (!options.silent) console.log("  Installing "+target+"...");
+
+			if (target.match(/^file:/)) {
+				// This is a target that was originally included via a local path or network-based name (URL, git ID).
+				// Move the cached package out of the cache before installing, because otherwise `npm` will have trouble
+				// figuring out what to do. (It doesn't like being asked to install from cache paths.)
+				var parts = target.match(/^file:((.+)-(.+)\.tgz)$/);
+				var fullName = parts[1];
+				var name = parts[2];
+				var version = parts[3];
+				target = path.resolve(work,fullName);
+				fs.mkdirSync(work); // We only create the `work` directory when needed.
+				fs.renameSync(path.resolve(cache,name,version,"package.tgz"),target);
+				target = "file:"+target;
+			}
 
 			npmInstall(target,function(err){
 				if (err) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "unbox"
   ],
   "description": "npm addon utility for creating and installing from an archive file of an npm install, including dependencies.",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "homepage": "http://github.com/arei/npmbox",
   "bugs": {
     "url": "http://github.com/arei/npmbox/issues"


### PR DESCRIPTION
This PR adds code to recognize `local` as a package type and treat it the same way as `git` and `hosted` do. In addition, for top-level targets, the flag file corresponding to all of these will be named in such a way that the unbox code will trigger a new code path which explicitly installs the cached `.tgz` file instead of trying to use `npm install` on the original path/URL (the latter which won't actually work in general).

This fixes issue #31.