### PR TITLE
`--install` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ UPDATE for v.next.
   * Start using a temporary directory instead of the CWD for temporary files and
     directories. **Note:** This fixes the problem noted in v4.1.0 whereby
     `npmbox` of the current directory would fail.
+  * New unbox option `--install=<pkg>` to install any package while using the
+    box contents for dependencies. This can be used to install a local package
+    (from the filesystem) while using a box for dependencies, e.g.
+    `cd path/to/my/package; npmunbox --install=. path/to/box.npmbox`
 
 UPDATE December 21, 2016: v4.1.0 of npmbox is out.
   * Support for running npmbox on a top-level local package, e.g.
@@ -83,6 +87,7 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
         -v, --verbose         Shows npm output which is normally hidden.
         -s, --silent          Shows additional output which is normally hidden.
         -p, --path            Specify the path to a folder from which the .npmbox file(s) will be read.
+        -i, --install=<pkg>   Installs the indicated package instead of using the .npmbox manifest.
         -g, --global          Installs package globally as if --global was passed to npm.
         -C, --prefix          npm --prefix switch.
         -S, --save            npm --save switch.
@@ -90,7 +95,6 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
         -O, --save-optional   npm --save-optional switch.
         -B, --save-bundle     npm --save-bundle switch.
         -E, --save-exact      npm --save-exact switch.
-
 
 You must specify at least one file.
 

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -26,11 +26,14 @@ var argv = require("optimist")
 		alias: "path",
 		default: process.cwd()
 	})
+	.options("i", {
+		alias: "install"
+	})
 	.argv;
 
 var args = argv._;
 if (args.length<1 || argv.help) {
-	console.log("npmunbox - Extracts a .npmbox file and installs the contained package.");
+	console.log("npmunbox - Extracts one or more .npmbox files and installs the contained package(s).");
 	console.log("");
 	console.log("Usage: ");
 	console.log("");
@@ -42,7 +45,8 @@ if (args.length<1 || argv.help) {
 	console.log("  -v, --verbose         Shows npm output which is normally hidden.");
 	console.log("  -s, --silent          Hide all output.");
 	console.log("  -p, --path            Specify the path to a folder from which the .npmbox file(s) will be read.");
-	console.log("  -g, --global          Installs package globally as if --global was passed to npm.");
+	console.log("  -i, --install=<pkg>   Installs the indicated package instead of using the .npmbox manifest.");
+	console.log("  -g, --global          Installs package(s) globally as if --global was passed to npm.");
 	console.log("  -C, --prefix          npm --prefix switch.");
 	console.log("  -S, --save            npm --save switch.");
 	console.log("  -D, --save-dev        npm --save-dev switch.");
@@ -66,8 +70,10 @@ var options = {
 };
 if (argv.C || argv.prefix) options.prefix = argv.C || argv.prefix;
 
-var sources = args;
 var errorCount = 0;
+var sources = args.filter(function(source){
+	return !!source;
+});
 
 var complete = function() {
 	boxxer.cleanup(function(){
@@ -75,32 +81,67 @@ var complete = function() {
 	});
 };
 
-var unboxDone = function(err) {
-	if (err) {
-		var args = utils.flatten(utils.toArray(arguments));
-		args.forEach(function(arg){
-			errorCount += 1;
-			console.error(" ",arg);
-		});
-	}
+var reportErrors = function(args) {
+	args.forEach(function(arg){
+		errorCount += 1;
+		console.error(" ",arg);
+	});
+}
+
+// Handles the case where we pay attention to the manifests inside the box(es).
+var unboxFromManifest = function() {
+	var unboxDone = function(err) {
+		if (err) reportErrors(utils.flatten(utils.toArray(arguments)));
+		unboxNext();
+	};
+
+	var unboxNext = function() {
+		var source = sources.shift();
+		if (!source) return complete();
+
+		unboxExecute(source);
+	};
+
+	var unboxExecute = function(source) {
+		if (!options.silent) console.log("\nUnboxing "+source+"...");
+		boxxer.unbox(source,options,unboxDone);
+	};
+
 	unboxNext();
-};
+}
 
-var unboxNext = function() {
-	var source = sources.shift();
-	if (!source) return complete();
+// Handles the case where we are installing a package listed via the `--install`
+// option. This unpacks all the boxes (on top of each other) and then does a
+// single `npm install`.
+var unboxWithInstallOption = function(pkg) {
+	var installDone = function(err) {
+		if (err) reportErrors(utils.flatten(utils.toArray(arguments)));
+		complete();
+	};
 
-	unboxExecute(source);
-};
+	var unpackDone = function(err) {
+		if (err) {
+			reportErrors(utils.flatten(utils.toArray(arguments)));
+			return complete();
+		}
+		unpackNext();
+	};
 
-var unboxExecute = function(source) {
-	if (!options.silent) console.log("\nUnboxing "+source+"...");
-	boxxer.unbox(source,options,unboxDone);
-};
+	var unpackNext = function() {
+		var source = sources.shift();
+		if (source) unpackExecute(source);
+		else {
+			boxxer.install(pkg,options,installDone);
+		}
+	};
 
-sources = sources.filter(function(source){
-	return !!source;
-});
+	var unpackExecute = function(source) {
+		boxxer.unpack(source,options,unpackDone);
+	};
 
-if (sources && sources.length>0) unboxNext();
-else complete();
+	unpackNext();
+}
+
+if (sources.length===0) return complete();
+else if (argv.install) unboxWithInstallOption(argv.install);
+else unboxFromManifest();


### PR DESCRIPTION
This is a fix for issue #51. The diffs here look scarier at first blush than they are in reality: What's going on here is that I factored out common code from the regular unbox path to also handle `--install`. So, a few chunks of code got rearranged / indented / outdented / tweaked; and I added just a little bit of actually-new code for the new option.