### PR TITLE
Add new options, prepare for 4.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ UPDATE for v.next.
     `cd path/to/my/package; npmunbox --install=. path/to/box.npmbox`
   * New unbox option `--scripts` to enable running of scripts. (By default,
     npmbox acts like `--ignore-scripts` was specified.)
+  * New options `--proxy` and `--https-proxy` which pass through to the
+    underlying `npm` invocation. Works on both `npmbox` and `npmunbox`. In the
+    latter case, this can help prevent unboxing from inadvertently hitting the
+    network (by specifying nonexistent proxies).
 
 UPDATE December 21, 2016: v4.1.0 of npmbox is out.
   * Support for running npmbox on a top-level local package, e.g.
@@ -59,6 +63,8 @@ Given some package, like `express` this command will create a archive file of th
         -v, --verbose         Shows npm output which is normally hidden.
         -s, --silent          Shows no output whatsoever.
         -t, --target          Specify the .npmbox file to write.
+        --proxy=<url>         npm --proxy switch.
+        --https-proxy=<url>   npm --https-proxy switch.
 
 You must specify at least one package. Packages can be anything accepted as
 an argument to `npm install`, and can also be a local path to a `.json` file,
@@ -98,6 +104,8 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
         -O, --save-optional   npm --save-optional switch.
         -B, --save-bundle     npm --save-bundle switch.
         -E, --save-exact      npm --save-exact switch.
+        --proxy=<url>         npm --proxy switch.
+        --https-proxy=<url>   npm --https-proxy switch.
 
 You must specify at least one file.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ UPDATE for v.next.
     box contents for dependencies. This can be used to install a local package
     (from the filesystem) while using a box for dependencies, e.g.
     `cd path/to/my/package; npmunbox --install=. path/to/box.npmbox`
+  * New unbox option `--scripts` to enable running of scripts. (By default,
+    npmbox acts like `--ignore-scripts` was specified.)
 
 UPDATE December 21, 2016: v4.1.0 of npmbox is out.
   * Support for running npmbox on a top-level local package, e.g.
@@ -88,6 +90,7 @@ Given some .npmbox file (must end with the .npmbox extension), installs the cont
         -s, --silent          Shows additional output which is normally hidden.
         -p, --path            Specify the path to a folder from which the .npmbox file(s) will be read.
         -i, --install=<pkg>   Installs the indicated package instead of using the .npmbox manifest.
+        --scripts             Enable running of scripts during installation.
         -g, --global          Installs package globally as if --global was passed to npm.
         -C, --prefix          npm --prefix switch.
         -S, --save            npm --save switch.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npmbox is intended to be a proof of concept with regards to this issue filled ag
 
 ## npmbox news
 
-UPDATE for v.next.
+UPDATE December 22, 2016: v4.2.0 of npmbox is out.
   * Support for accepting a `package.json` file when boxing. This will cause its
     dependencies to get boxed.
   * Start using a temporary directory instead of the CWD for temporary files and

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,11 +1,16 @@
 {
   "name": "npmbox",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "dependencies": {
     "assertion-error": {
       "version": "1.0.2",
       "from": "assertion-error@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
     "block-stream": {
       "version": "0.0.9",
@@ -17,6 +22,16 @@
       "from": "bluebird@>=2.9.34 <3.0.0",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
     },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+    },
     "chai": {
       "version": "3.5.0",
       "from": "chai@>=3.2.0 <4.0.0",
@@ -26,6 +41,11 @@
       "version": "2.9.0",
       "from": "commander@>=2.8.1 <3.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
     },
     "debug": {
       "version": "2.2.0",
@@ -84,6 +104,16 @@
       "from": "growl@1.9.2",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
     },
+    "hosted-git-info": {
+      "version": "2.1.5",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+    },
     "inherits": {
       "version": "2.0.1",
       "from": "inherits@>=2.0.0 <2.1.0",
@@ -93,6 +123,11 @@
       "version": "3.1.0",
       "from": "is@3.1.0",
       "resolved": "https://registry.npmjs.org/is/-/is-3.1.0.tgz"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
     },
     "jade": {
       "version": "0.26.3",
@@ -110,6 +145,16 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
         }
       }
+    },
+    "jju": {
+      "version": "1.3.0",
+      "from": "jju@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz"
+    },
+    "json-parse-helpfulerror": {
+      "version": "1.0.3",
+      "from": "json-parse-helpfulerror@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz"
     },
     "jsonfile": {
       "version": "2.4.0",
@@ -178,6 +223,11 @@
       "version": "0.7.1",
       "from": "ms@0.7.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+    },
+    "normalize-package-data": {
+      "version": "2.3.5",
+      "from": "normalize-package-data@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz"
     },
     "npm": {
       "version": "3.10.3",
@@ -1661,6 +1711,11 @@
         }
       }
     },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
     "optimist": {
       "version": "0.6.1",
       "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -1675,6 +1730,33 @@
           "version": "0.0.3",
           "from": "wordwrap@>=0.0.2 <0.1.0",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        }
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "from": "os-tmpdir@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+    },
+    "read-package-json": {
+      "version": "2.0.4",
+      "from": "read-package-json@2.0.4",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
+      "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "from": "glob@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
         }
       }
     },
@@ -1755,10 +1837,30 @@
         }
       }
     },
+    "semver": {
+      "version": "5.3.0",
+      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+    },
     "sigmund": {
       "version": "1.0.1",
       "from": "sigmund@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
     },
     "supports-color": {
       "version": "1.2.0",
@@ -1775,6 +1877,11 @@
       "from": "tar.gz@1.0.2",
       "resolved": "https://registry.npmjs.org/tar.gz/-/tar.gz-1.0.2.tgz"
     },
+    "tmp": {
+      "version": "0.0.31",
+      "from": "tmp@0.0.31",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz"
+    },
     "to-iso-string": {
       "version": "0.0.2",
       "from": "to-iso-string@0.0.2",
@@ -1784,6 +1891,16 @@
       "version": "1.0.0",
       "from": "type-detect@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
     }
   }
 }

--- a/npmbox.js
+++ b/npmbox.js
@@ -8,6 +8,10 @@
 var boxxer = require("./npmboxxer.js");
 
 var argv = require("optimist")
+	.string([
+		"proxy",
+		"https-proxy"
+	])
 	.boolean(["v","verbose","s","silent"])
 	.options("t", {
 		alias: "target",
@@ -29,6 +33,8 @@ if (args.length<1 || argv.help) {
 	console.log("  -v, --verbose         Shows additional output which is normally hidden.");
 	console.log("  -s, --silent          Hide all output.");
 	console.log("  -t, --target          Specify the target .npmbox file to write.");
+	console.log("  --proxy=<url>         npm --proxy switch.");
+	console.log("  --https-proxy=<url>   npm --https-proxy switch.");
 	console.log("");
 	process.exit(0);
 }
@@ -36,7 +42,9 @@ if (args.length<1 || argv.help) {
 var options = {
 	verbose: argv.v || argv.verbose || false,
 	silent: argv.s || argv.silent || false,
-	target: argv.t || argv.target || null
+	target: argv.t || argv.target || null,
+	proxy: argv.proxy || null,
+	"https-proxy": argv["https-proxy"] || null
 };
 
 var sources = args;

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -404,7 +404,6 @@
 		options.loglevel = options.verbose ? "verbose" : "silent";
 		options.progress = false;
 		options.color = false;
-		options["ignore-scripts"] = true;
 		options["cache-min"] = 1000 * 365.25 * 24 * 60 * 60; // a thousand years
 		options["fetch-retries"] = 0;
 		options["fetch-retry-factor"] = 0;

--- a/npmboxxer.js
+++ b/npmboxxer.js
@@ -357,6 +357,8 @@
 				"ignore-scripts": true,
 				loglevel: options && options.verbose ? "http" : "silent"
 			};
+			if (options.proxy) npmoptions.proxy = options.proxy;
+			if (options["https-proxy"]) npmoptions["https-proxy"] = options["https-proxy"];
 
 			npmInit(npmoptions,function(err){
 				if (err) return done(err);

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -16,6 +16,7 @@ var argv = require("optimist")
 		"v","verbose",
 		"s","silent",
 		"g","global",
+		"scripts",
 		"S","save",
 		"D","save-dev",
 		"O","save-optional",
@@ -46,6 +47,7 @@ if (args.length<1 || argv.help) {
 	console.log("  -s, --silent          Hide all output.");
 	console.log("  -p, --path            Specify the path to a folder from which the .npmbox file(s) will be read.");
 	console.log("  -i, --install=<pkg>   Installs the indicated package instead of using the .npmbox manifest.");
+	console.log("  --scripts             Enable running of scripts during installation.");
 	console.log("  -g, --global          Installs package(s) globally as if --global was passed to npm.");
 	console.log("  -C, --prefix          npm --prefix switch.");
 	console.log("  -S, --save            npm --save switch.");
@@ -66,6 +68,7 @@ var options = {
 	"save-optional": argv.O || argv["save-optional"] || false,
 	"save-bundle": argv.B || argv["save-bundle"] || false,
 	"save-exact": argv.E || argv["save-exact"] || false,
+	"ignore-scripts": !argv.scripts,
 	path: argv.p || argv.path || false
 };
 if (argv.C || argv.prefix) options.prefix = argv.C || argv.prefix;

--- a/npmunbox.js
+++ b/npmunbox.js
@@ -10,7 +10,9 @@ var utils = require("./utils");
 
 var argv = require("optimist")
 	.string([
-		"C","prefix"
+		"C","prefix",
+		"proxy",
+		"https-proxy"
 	])
 	.boolean([
 		"v","verbose",
@@ -55,6 +57,8 @@ if (args.length<1 || argv.help) {
 	console.log("  -O, --save-optional   npm --save-optional switch.");
 	console.log("  -B, --save-bundle     npm --save-bundle switch.");
 	console.log("  -E, --save-exact      npm --save-exact switch.");
+	console.log("  --proxy=<url>         npm --proxy switch.");
+	console.log("  --https-proxy=<url>   npm --https-proxy switch.");
 	console.log("");
 	process.exit(0);
 }
@@ -72,6 +76,8 @@ var options = {
 	path: argv.p || argv.path || false
 };
 if (argv.C || argv.prefix) options.prefix = argv.C || argv.prefix;
+if (argv.proxy) options.proxy = argv.proxy;
+if (argv["https-proxy"]) options["https-proxy"] = argv["https-proxy"];
 
 var errorCount = 0;
 var sources = args.filter(function(source){

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "unbox"
   ],
   "description": "npm addon utility for creating and installing from an archive file of an npm install, including dependencies.",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "homepage": "http://github.com/arei/npmbox",
   "bugs": {
     "url": "http://github.com/arei/npmbox/issues"


### PR DESCRIPTION
* Add `--scripts` option to `npmunbox` (issue #79).
* Add `--proxy` and `--https-proxy` options to both `npmbox` and `npmunbox` (issue #80).
* Prep for the 4.2.0 release: Update README, package, and shrinkwrap files.