### PR TITLE
Replace private Uber repo

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -267,7 +267,7 @@
         "asap": {
           "version": "2.0.4",
           "from": "asap@latest",
-          "resolved": "https://unpm.uberinternal.com/asap/-/asap-2.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
         },
         "chownr": {
           "version": "1.0.1",


### PR DESCRIPTION
Replace In shrinkwrap file private Uber repo with original npm registry.

More about this problem read here: 
https://github.com/kriskowal/asap/issues/70

This Pull Request was created according to this issue:
https://github.com/arei/npmbox/issues/90